### PR TITLE
Use javascript API directly to run acceptance tests

### DIFF
--- a/javascript/test/acceptance.ts
+++ b/javascript/test/acceptance.ts
@@ -1,11 +1,12 @@
+import { NdjsonToMessageStream } from '@cucumber/message-streams'
 import assert from 'assert'
-import { exec } from 'child_process'
+import fs from 'fs'
 import glob from 'glob'
 import path from 'path'
 import puppeteer from 'puppeteer'
-import util from 'util'
+import { pipeline } from 'stream'
 
-const run = util.promisify(exec)
+import CucumberHtmlStream from '../src/CucumberHtmlStream'
 
 async function canRenderHtml(html: string): Promise<boolean> {
   const browser = await puppeteer.launch({
@@ -28,17 +29,35 @@ async function canRenderHtml(html: string): Promise<boolean> {
 }
 
 describe('html-formatter', () => {
-  for (const ndjson of glob.sync(
+  const files = glob.sync(
     `./node_modules/@cucumber/compatibility-kit/features/**/*.ndjson`
-  )) {
+  )
+  for (const ndjson of files) {
     it(`can render ${path.basename(ndjson, '.ndjson')}`, async () => {
-      // const ndjsonData = fs.readFileSync(ndjson, { encoding: 'utf-8' })
-      const { stdout: htmlData } = await run(
-        `npx shx cat ${ndjson} | node ./bin/cucumber-html-formatter.js`,
-        { maxBuffer: 4096 * 1024 }
-      )
+      const ndjsonData = fs.readFileSync(ndjson, { encoding: 'utf-8' })
+      const toMessageStream = new NdjsonToMessageStream()
+      let htmlData = Buffer.from('')
+      await new Promise((resolve, reject) => {
+        pipeline(
+          ndjsonData,
+          toMessageStream,
+          new CucumberHtmlStream(
+            __dirname + '/../dist/main.css',
+            __dirname + '/../dist/main.js'
+          ),
+          (err: Error) => {
+            if (err) {
+              reject(err)
+            }
+          }
+        )
+          .on('data', (chunk) => {
+            htmlData = Buffer.concat([htmlData, Buffer.from(chunk)])
+          })
+          .on('end', resolve)
+      })
 
-      assert.ok(await canRenderHtml(htmlData))
+      assert.ok(await canRenderHtml(htmlData.toString()))
     })
   }
 })


### PR DESCRIPTION
<!---
Thanks for submitting a pull request!

The prompts below (the _bits in italics_) are for guidance to help you describe your change in a way that is most likely to make sense to other people when they are reviewing it. Still, it's just a guide, so feel free to delete anything that doesn't feel appropriate, and add anything additional that seems like it would probide useful context.

Please either replace the promopts with your own words, or delete them.
-->

# Description

Modifies `javascript/test/acceptance.ts` to use the `CucumberHtmlStream` object directly, rather than shelling out to the command-line wrapper.

# Motivation & context

Pre-factoring for removing the `javascript/bin` entrypoint as part of #4

## Type of change

- Refactoring/debt (improvement to code design or tooling without changing behaviour)

# Checklist:

<!--- 
Go over all the following points, and put an `x` in all the boxes that apply. 
-->

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
