### PR TITLE
Add new polyglot release script wrapper

### DIFF
--- a/release
+++ b/release
@@ -1,0 +1,6 @@
+#!/bin/bash
+TMP_FILE=$(mktemp)
+BOOTSTRAPPER_NAME=$0
+curl --silent -o "$TMP_FILE" https://raw.githubusercontent.com/cucumber/polyglot-release/main/release
+chmod 744 "$TMP_FILE"
+$TMP_FILE $@


### PR DESCRIPTION
### 🤔 What's changed?

* Added wrapper executable to call https://github.com/cucumber/polyglot-release from the CLI

### ⚡️ What's your motivation? 

Release 19.0.1 without doing any manual steps.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without 

### ♻️ Anything particular you want feedback on?

@aurelien-reeves would you like to give it a try?

It should be a simple as `./release 19.0.1`

If you want to do a "dry run" try:

    ./release 19.0.1 --no-git-push --no-git-commit

Note that the usage instructions will be a bit ugly until https://github.com/cucumber/polyglot-release/pull/7 is merged.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
