### PR TITLE
CI: Use Node 18, 20

### DIFF
--- a/.github/workflows/release-javascript.yml
+++ b/.github/workflows/release-javascript.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "17"
+          node-version: 18
           cache: "npm"
           cache-dependency-path: javascript/package-lock.json
 

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -18,12 +18,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node-version: ["14.x", "17.x"]
+        node-version: [18, 20]
         include:
           - os: windows-latest
-            node-version: "17.x"
+            node-version: 18
           - os: macos-latest
-            node-version: "17.x"
+            node-version: 18
 
     steps:
       - name: set git core.autocrlf to 'input'


### PR DESCRIPTION


### 🤔 What's changed?

Fix #219 by changing the build matrix to use newer versions.

### ⚡️ What's your motivation? 

In order to keep up with Node versions that are current, and also, to conserve CI resources, use two Node.js versions. The two that are shown on the Node.js website.

I will also update the other Workflow.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

