### PR TITLE
Escape html comments in json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Upgrade `react-components` to [23.2.0](https://github.com/cucumber/react-components/releases/tag/v23.2.0)
 
+### Fixed
+- Escape html comments in json ([#408](https://github.com/cucumber/html-formatter/pull/408))
+
 ## [21.13.0] - 2025-07-07
 ### Changed
 - Upgrade `cucumber-messages` to [28.0.0](https://github.com/cucumber/messages/releases/tag/v28.0.0)

--- a/dotnet/Cucumber.HtmlFormatter/JsonInHtmlWriter.cs
+++ b/dotnet/Cucumber.HtmlFormatter/JsonInHtmlWriter.cs
@@ -33,7 +33,8 @@ public class JsonInHtmlWriter : StreamWriter
             throw new ArgumentException("Cannot read past the end of the input source char array.");
 
         var destination = PrepareBuffer();
-        var flushAt = BUFFER_SIZE - 2;
+        // Largest write without boundary check is 4 bytes
+        var flushAt = BUFFER_SIZE - 4;
         var written = 0;
         for (var i = offset; i < offset + length; i++)
         {
@@ -46,12 +47,19 @@ public class JsonInHtmlWriter : StreamWriter
                 written = 0;
             }
 
-            // Write with escapes
-            if (c == '/')
+            // Replace < with \x3C
+            // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+            if (c == '<')
             {
                 destination[written++] = '\\';
+                destination[written++] = 'x';
+                destination[written++] = '3';
+                destination[written++] = 'C';
+            } 
+            else
+            {
+                destination[written++] = c;
             }
-            destination[written++] = c;
         }
         // Flush any remaining
         if (written > 0)
@@ -66,7 +74,8 @@ public class JsonInHtmlWriter : StreamWriter
             throw new ArgumentException("Cannot read past the end of the input source char array.");
 
         var destination = PrepareBuffer();
-        var flushAt = BUFFER_SIZE - 2;
+        // Largest write without boundary check is 4 bytes
+        var flushAt = BUFFER_SIZE - 4;
         var written = 0;
         for (var i = offset; i < offset + length; i++)
         {
@@ -79,12 +88,19 @@ public class JsonInHtmlWriter : StreamWriter
                 written = 0;
             }
 
-            // Write with escapes
-            if (c == '/')
+            // Replace < with \x3C
+            // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+            if (c == '<')
             {
                 destination[written++] = '\\';
+                destination[written++] = 'x';
+                destination[written++] = '3';
+                destination[written++] = 'C';
+            } 
+            else
+            {
+                destination[written++] = c;
             }
-            destination[written++] = c;
         }
         // Flush any remaining
         if (written > 0)

--- a/dotnet/Cucumber.HtmlFormatterTest/JsonInHtmlWriterTests.cs
+++ b/dotnet/Cucumber.HtmlFormatterTest/JsonInHtmlWriterTests.cs
@@ -32,29 +32,29 @@ public sealed class JsonInHtmlWriterTests
     [TestMethod]
     public void EscapesSingle()
     {
-        _writer.Write("/");
-        Assert.AreEqual("\\/", Output());
+        _writer.Write("<");
+        Assert.AreEqual("\\x3C", Output());
     }
 
     [TestMethod]
     public async Task EscapesSingleAsync()
     {
-        await _writer.WriteAsync("/");
-        Assert.AreEqual("\\/", await OutputAsync());
+        await _writer.WriteAsync("<");
+        Assert.AreEqual("\\x3C", await OutputAsync());
     }
 
     [TestMethod]
     public void EscapesMultiple()
     {
         _writer.Write("</script><script></script>");
-        Assert.AreEqual("<\\/script><script><\\/script>", Output());
+        Assert.AreEqual("\\x3C/script>\\x3Cscript>\\x3C/script>", Output());
     }
 
     [TestMethod]
     public async Task EscapesMultipleAsync()
     {
         await _writer.WriteAsync("</script><script></script>");
-        Assert.AreEqual("<\\/script><script><\\/script>", await OutputAsync());
+        Assert.AreEqual("\\x3C/script>\\x3Cscript>\\x3C/script>", await OutputAsync());
     }
 
     [TestMethod]
@@ -72,7 +72,7 @@ public sealed class JsonInHtmlWriterTests
         text.CopyTo(17, buffer, 4, 9);
         _writer.Write(buffer, 4, 9);
 
-        Assert.AreEqual("<\\/script><script><\\/script>", Output());
+        Assert.AreEqual("\\x3C/script>\\x3Cscript>\\x3C/script>", Output());
     }
 
     [TestMethod]
@@ -90,7 +90,7 @@ public sealed class JsonInHtmlWriterTests
         text.CopyTo(17, buffer, 4, 9);
         await _writer.WriteAsync(buffer, 4, 9);
 
-        Assert.AreEqual("<\\/script><script><\\/script>", await OutputAsync());
+        Assert.AreEqual("\\x3C/script>\\x3Cscript>\\x3C/script>", await OutputAsync());
     }
     [TestMethod]
     public void LargeWritesWithOddBoundaries()
@@ -99,7 +99,7 @@ public sealed class JsonInHtmlWriterTests
         buffer[0] = 'a';
         for (int i = 1; i < buffer.Length; i++)
         {
-            buffer[i] = '/';
+            buffer[i] = '<';
         }
         _writer.Write(buffer);
 
@@ -107,7 +107,7 @@ public sealed class JsonInHtmlWriterTests
         expected.Append('a');
         for (int i = 1; i < buffer.Length; i++)
         {
-            expected.Append("\\/");
+            expected.Append("\\x3C");
         }
         Assert.AreEqual(expected.ToString(), Output());
     }
@@ -119,7 +119,7 @@ public sealed class JsonInHtmlWriterTests
         buffer[0] = 'a';
         for (int i = 1; i < buffer.Length; i++)
         {
-            buffer[i] = '/';
+            buffer[i] = '<';
         }
         await _writer.WriteAsync(buffer);
 
@@ -127,7 +127,7 @@ public sealed class JsonInHtmlWriterTests
         expected.Append('a');
         for (int i = 1; i < buffer.Length; i++)
         {
-            expected.Append("\\/");
+            expected.Append("\\x3C");
         }
         Assert.AreEqual(expected.ToString(), await OutputAsync());
     }
@@ -138,14 +138,14 @@ public sealed class JsonInHtmlWriterTests
         char[] buffer = new char[2048];
         for (int i = 0; i < buffer.Length; i++)
         {
-            buffer[i] = '/';
+            buffer[i] = '<';
         }
         _writer.Write(buffer);
 
         StringBuilder expected = new StringBuilder();
         for (int i = 0; i < buffer.Length; i++)
         {
-            expected.Append("\\/");
+            expected.Append("\\x3C");
         }
         Assert.AreEqual(expected.ToString(), Output());
     }
@@ -156,14 +156,14 @@ public sealed class JsonInHtmlWriterTests
         char[] buffer = new char[2048];
         for (int i = 0; i < buffer.Length; i++)
         {
-            buffer[i] = '/';
+            buffer[i] = '<';
         }
         await _writer.WriteAsync(buffer);
 
         StringBuilder expected = new StringBuilder();
         for (int i = 0; i < buffer.Length; i++)
         {
-            expected.Append("\\/");
+            expected.Append("\\x3C");
         }
         Assert.AreEqual(expected.ToString(), await OutputAsync());
     }

--- a/dotnet/Cucumber.HtmlFormatterTest/MessagesToHtmlWriterTest.cs
+++ b/dotnet/Cucumber.HtmlFormatterTest/MessagesToHtmlWriterTest.cs
@@ -173,7 +173,7 @@ public class MessagesToHtmlWriterTest
     }
 
     [TestMethod]
-    public void ItEscapesForwardSlashes()
+    public void ItEscapesOpeningAngleBracket()
     {
         Envelope envelope = Envelope.Create(new GherkinDocument(
             null,
@@ -181,13 +181,13 @@ public class MessagesToHtmlWriterTest
             [new(new Location(0L, 0L), "</script><script>alert('Hello')</script>")]
         ));
         string html = RenderAsHtml(envelope);
-        Assert.IsTrue(html.Contains("window.CUCUMBER_MESSAGES = [{\"gherkinDocument\":{\"comments\":[{\"location\":{\"line\":0,\"column\":0},\"text\":\"<\\/script><script>alert('Hello')<\\/script>\"}]}}];"),
-            $"Expected \"window.CUCUMBER_MESSAGES = [{{\\\"gherkinDocument\\\":{{\\\"comments\\\":[{{\\\"location\\\":{{\\\"line\\\":0,\\\"column\\\":0}},\\\"text\\\":\\\"<\\\\/script><script>alert('Hello')<\\\\/script>\\\"}}]}}];" +
+        Assert.IsTrue(html.Contains("window.CUCUMBER_MESSAGES = [{\"gherkinDocument\":{\"comments\":[{\"location\":{\"line\":0,\"column\":0},\"text\":\"\\x3C/script>\\x3Cscript>alert('Hello')\\x3C/script>\"}]}}];"),
+            $"Expected \"window.CUCUMBER_MESSAGES = [{{\\\"gherkinDocument\\\":{{\\\"comments\\\":[{{\\\"location\\\":{{\\\"line\\\":0,\\\"column\\\":0}},\\\"text\\\":\\\"\\\\x3C/script>\\\\x3Cscript>alert('Hello')\\\\x3C/script>\\\"}}]}}];" +
             $"\nbut instead had: \n{html.Substring(html.IndexOf("window.CUCUMBER"))}");
     }
 
     [TestMethod]
-    public async Task ItEscapesForwardSlashesAsync()
+    public async Task ItEscapesOpeningAngleBracketAsync()
     {
         Envelope envelope = Envelope.Create(new GherkinDocument(
             null,
@@ -195,8 +195,8 @@ public class MessagesToHtmlWriterTest
             [new(new Location(0L, 0L), "</script><script>alert('Hello')</script>")]
         ));
         string html = await RenderAsHtmlAsync(envelope);
-        Assert.IsTrue(html.Contains("window.CUCUMBER_MESSAGES = [{\"gherkinDocument\":{\"comments\":[{\"location\":{\"line\":0,\"column\":0},\"text\":\"<\\/script><script>alert('Hello')<\\/script>\"}]}}];"),
-            $"Expected \"window.CUCUMBER_MESSAGES = [{{\\\"gherkinDocument\\\":{{\\\"comments\\\":[{{\\\"location\\\":{{\\\"line\\\":0,\\\"column\\\":0}},\\\"text\\\":\\\"<\\\\/script><script>alert('Hello')<\\\\/script>\\\"}}]}}];" +
+        Assert.IsTrue(html.Contains("window.CUCUMBER_MESSAGES = [{\"gherkinDocument\":{\"comments\":[{\"location\":{\"line\":0,\"column\":0},\"text\":\"\\x3C/script>\\x3Cscript>alert('Hello')\\x3C/script>\"}]}}];"),
+            $"Expected \"window.CUCUMBER_MESSAGES = [{{\\\"gherkinDocument\\\":{{\\\"comments\\\":[{{\\\"location\\\":{{\\\"line\\\":0,\\\"column\\\":0}},\\\"text\\\":\\\"\\\\x3C/script>\\\\x3Cscript>alert('Hello')\\\\x3C/script>\\\"}}]}}];" +
             $"\nbut instead had: \n{html.Substring(html.IndexOf("window.CUCUMBER"))}");
     }
 

--- a/java/src/main/java/io/cucumber/htmlformatter/JsonInHtmlWriter.java
+++ b/java/src/main/java/io/cucumber/htmlformatter/JsonInHtmlWriter.java
@@ -19,7 +19,8 @@ class JsonInHtmlWriter extends Writer {
     @Override
     public void write(char[] source, int offset, int length) throws IOException {
         char[] destination = prepareBuffer();
-        int flushAt = BUFFER_SIZE - 2;
+        // Largest write without boundary check is 4 bytes
+        int flushAt = BUFFER_SIZE - 4;
         int written = 0;
         for (int i = offset; i < offset + length; i++) {
             char c = source[i];
@@ -30,11 +31,16 @@ class JsonInHtmlWriter extends Writer {
                 written = 0;
             }
 
-            // Write with escapes
-            if (c == '/') {
+            // Replace < with \x3C
+            // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+            if (c == '<') {
                 destination[written++] = '\\';
+                destination[written++] = 'x';
+                destination[written++] = '3';
+                destination[written++] = 'C';
+            } else {
+                destination[written++] = c;
             }
-            destination[written++] = c;
         }
         // Flush any remaining
         if (written > 0) {

--- a/java/src/test/java/io/cucumber/htmlformatter/JsonInHtmlWriterTest.java
+++ b/java/src/test/java/io/cucumber/htmlformatter/JsonInHtmlWriterTest.java
@@ -24,14 +24,14 @@ class JsonInHtmlWriterTest {
 
     @Test
     void escapes_single() throws IOException {
-        writer.write("/");
-        assertEquals("\\/", output());
+        writer.write("<");
+        assertEquals("\\x3C", output());
     }
 
     @Test
     void escapes_multiple() throws IOException {
         writer.write("</script><script></script>");
-        assertEquals("<\\/script><script><\\/script>", output());
+        assertEquals("\\x3C/script>\\x3Cscript>\\x3C/script>", output());
     }
 
     @Test
@@ -48,7 +48,7 @@ class JsonInHtmlWriterTest {
         text.getChars(17, 26, buffer, 4);
         writer.write(buffer, 4, 9);
 
-        assertEquals("<\\/script><script><\\/script>", output());
+        assertEquals("\\x3C/script>\\x3Cscript>\\x3C/script>", output());
     }
 
     @Test
@@ -56,13 +56,13 @@ class JsonInHtmlWriterTest {
         char[] buffer = new char[1024];
         // This forces the buffer to flush after every 1023 written characters.
         buffer[0] = 'a';
-        Arrays.fill(buffer, 1, buffer.length, '/');
+        Arrays.fill(buffer, 1, buffer.length, '<');
         writer.write(buffer);
 
         StringBuilder expected = new StringBuilder();
         expected.append("a");
         for (int i = 1; i < buffer.length; i++) {
-            expected.append("\\/");
+            expected.append("\\x3C");
         }
         assertEquals(expected.toString(), output());
     }
@@ -71,12 +71,12 @@ class JsonInHtmlWriterTest {
     @Test
     void really_large_writes() throws IOException {
         char[] buffer = new char[2048];
-        Arrays.fill(buffer, '/');
+        Arrays.fill(buffer, '<');
         writer.write(buffer);
 
         StringBuilder expected = new StringBuilder();
         for (int i = 0; i < buffer.length; i++) {
-            expected.append("\\/");
+            expected.append("\\x3C");
         }
         assertEquals(expected.toString(), output());
     }

--- a/java/src/test/java/io/cucumber/htmlformatter/MessagesToHtmlWriterTest.java
+++ b/java/src/test/java/io/cucumber/htmlformatter/MessagesToHtmlWriterTest.java
@@ -4,7 +4,6 @@ import io.cucumber.htmlformatter.MessagesToHtmlWriter.Serializer;
 import io.cucumber.messages.Convertor;
 import io.cucumber.messages.types.Comment;
 import io.cucumber.messages.types.Envelope;
-import io.cucumber.messages.types.Feature;
 import io.cucumber.messages.types.GherkinDocument;
 import io.cucumber.messages.types.Location;
 import io.cucumber.messages.types.TestRunFinished;
@@ -14,8 +13,6 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
@@ -91,7 +88,7 @@ class MessagesToHtmlWriterTest {
 
 
     @Test
-    void it_escapes_forward_slashes() throws IOException {
+    void it_escapes_opening_angle_bracket() throws IOException {
         Envelope envelope = Envelope.of(new GherkinDocument(
                 null,
                 null,
@@ -102,7 +99,7 @@ class MessagesToHtmlWriterTest {
         ));
         String html = renderAsHtml(envelope);
         assertThat(html, containsString(
-                "window.CUCUMBER_MESSAGES = [{\"gherkinDocument\":{\"comments\":[{\"location\":{\"line\":0,\"column\":0},\"text\":\"<\\/script><script>alert('Hello')<\\/script>\"}]}}];"));
+                "window.CUCUMBER_MESSAGES = [{\"gherkinDocument\":{\"comments\":[{\"location\":{\"line\":0,\"column\":0},\"text\":\"\\x3C/script>\\x3Cscript>alert('Hello')\\x3C/script>\"}]}}];"));
     }
 
     private static String renderAsHtml(Envelope... messages) throws IOException {

--- a/javascript/src/CucumberHtmlStream.spec.ts
+++ b/javascript/src/CucumberHtmlStream.spec.ts
@@ -91,7 +91,7 @@ describe('CucumberHtmlStream', () => {
     const html = await renderAsHtml(e1)
     assert(
       html.indexOf(
-        `window.CUCUMBER_MESSAGES = [{"gherkinDocument":{"comments":[{"location":{"line":0,"column":0},"text":"<\\/script><script>alert('Hello')<\\/script>"}]}}];`
+        `window.CUCUMBER_MESSAGES = [{"gherkinDocument":{"comments":[{"location":{"line":0,"column":0},"text":"\\x3C/script>\\x3Cscript>alert('Hello')\\x3C/script>"}]}}];`
       ) >= 0
     )
   })

--- a/javascript/src/CucumberHtmlStream.ts
+++ b/javascript/src/CucumberHtmlStream.ts
@@ -116,6 +116,8 @@ export class CucumberHtmlStream extends Transform {
     } else {
       this.push(',')
     }
-    this.push(JSON.stringify(envelope).replace(/\//g, '\\/'))
+    // Replace < with \x3C
+    // https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+    this.push(JSON.stringify(envelope).replace(/</g, '\\x3C'))
   }
 }

--- a/ruby/lib/cucumber/html_formatter/formatter.rb
+++ b/ruby/lib/cucumber/html_formatter/formatter.rb
@@ -23,7 +23,9 @@ module Cucumber
 
       def write_message(message)
         out.puts(',') unless @first_message
-        out.print(message.to_json.gsub('/', '\/'))
+        # Replace < with \x3C
+        # https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+        out.print(message.to_json.gsub('<', "\\x3C"))
 
         @first_message = false
       end

--- a/ruby/spec/cucumber/html_formatter/formatter_spec.rb
+++ b/ruby/spec/cucumber/html_formatter/formatter_spec.rb
@@ -79,10 +79,10 @@ describe Cucumber::HTMLFormatter::Formatter do
         expect(out.string).to eq("#{message.to_json},\n#{message.to_json}")
       end
 
-      it 'escapes forward slashes' do
+      it 'escapes opening angle bracket' do
         formatter.write_message(message_with_slashes)
 
-        expect(out.string).to eq('{"gherkinDocument":{"comments":[{"location":{"line":0,"column":0},"text":"<\/script><script>alert(\'Hello\')<\/script>"}]}}')
+        expect(out.string).to eq('{"gherkinDocument":{"comments":[{"location":{"line":0,"column":0},"text":"\\x3C/script>\\x3Cscript>alert(\'Hello\')\\x3C/script>"}]}}')
       end
     end
 


### PR DESCRIPTION
### 🤔 What's changed?

In brief, explained in more detail by Jon Surrel[1], both `</script>` and `<!--` are interpreted by the html render. We caught the first one, but not the second.

The W3C recommendation is to replace the `<` with `\x3C`[2] instead of escaping the `/`.

1. https://sirre.al/2025/08/06/safe-json-in-script-tags-how-not-to-break-a-site/
2. https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
