### PR TITLE
ruby: Remove redundant test against cck

### DIFF
--- a/ruby/cucumber-html-formatter.gemspec
+++ b/ruby/cucumber-html-formatter.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'cucumber-messages', '> 19', '< 28'
 
-  s.add_development_dependency 'cucumber-compatibility-kit', '~> 15.2'
   s.add_development_dependency 'rake', '~> 13.2'
   s.add_development_dependency 'rspec', '~> 3.13'
   s.add_development_dependency 'rubocop', '~> 1.71.0'

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -3,4 +3,3 @@
 require 'cucumber/html_formatter'
 
 require 'cucumber/messages'
-require 'cucumber-compatibility-kit'


### PR DESCRIPTION
### ⚡️ What's your motivation? 
The main purpose of the formatter is to write the given template correctly. This is already covered by the non-cck tests. As such the dependency on the CCK doesn't add anything.

The cck incidentally does check that the empty report is written correctly. Which can be done with a fairly minimal test.


### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?

Partially related to https://github.com/cucumber/compatibility-kit/issues/145. While it won't fix that issue, I reckon this is the right approach in this repository. 

### 📋 Checklist:



- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
