### PR TITLE
Use Playwright image in CI

### DIFF
--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -49,8 +49,28 @@ jobs:
         working-directory: javascript
       - run: npm test
         working-directory: javascript
-      - name: Setup browsers
-        run: npx playwright install --with-deps
+
+  test-acceptance:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.54.2-jammy
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+
+    steps:
+      - name: set git core.autocrlf to 'input'
+        run: git config --global core.autocrlf input
+      - uses: actions/checkout@v5
+      - name: with Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: javascript
+      - run: npm run build
+        working-directory: javascript
       - name: Acceptance tests
         working-directory: javascript
         run: npm run acceptance


### PR DESCRIPTION
### 🤔 What's changed?

Split out a separate job in GitHub actions for the Playwright acceptance tests, and use the Microsoft-maintained image with the browser pre-installed.

### ⚡️ What's your motivation? 

The previous approach of doing `playwright install` per run was unreliable.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
